### PR TITLE
Change placeholder syntax to support postgres too

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func HandleCard(uid []byte) (Result, error) {
 
 	// Get user this card belongs to
 	var user User
-	if err := tx.Get(&user, `SELECT users.user_id, name, password FROM cards LEFT JOIN users ON cards.user_id = users.user_id WHERE card_id = ?`, uid); err != nil {
+	if err := tx.Get(&user, `SELECT users.user_id, name, password FROM cards LEFT JOIN users ON cards.user_id = users.user_id WHERE card_id = $1`, uid); err != nil {
 		log.Println("Card not found in database")
 		return 0, ErrCardNotFound
 	}
@@ -111,7 +111,7 @@ func HandleCard(uid []byte) (Result, error) {
 	// Get account balance of this user
 	var balance int64
 	var b sql.NullInt64
-	if err := tx.Get(&b, `SELECT SUM(amount) FROM transactions WHERE user_id = ?`, user.ID); err != nil {
+	if err := tx.Get(&b, `SELECT SUM(amount) FROM transactions WHERE user_id = $1`, user.ID); err != nil {
 		log.Println("Could not get balance:", err)
 		return 0, err
 	}
@@ -125,7 +125,7 @@ func HandleCard(uid []byte) (Result, error) {
 	}
 
 	// Insert new transaction
-	if _, err := tx.Exec(`INSERT INTO transactions (user_id, card_id, time, amount, kind) VALUES (?, ?, ?, ?, ?)`, user.ID, uid, time.Now(), -100, "Kartenswipe"); err != nil {
+	if _, err := tx.Exec(`INSERT INTO transactions (user_id, card_id, time, amount, kind) VALUES ($1, $2, $3, $4, $5)`, user.ID, uid, time.Now(), -100, "Kartenswipe"); err != nil {
 		return 0, err
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -41,19 +41,19 @@ func createDB(t *testing.T) *sqlx.DB {
 
 func insertData(t *testing.T, db *sqlx.DB, us []User, cs []Card, ts []Transaction) {
 	for _, v := range us {
-		_, err := db.Exec("INSERT INTO users (user_id, name, password) VALUES (?, ?, ?)", v.ID, v.Name, v.Password)
+		_, err := db.Exec("INSERT INTO users (user_id, name, password) VALUES ($1, $2, $3)", v.ID, v.Name, v.Password)
 		if err != nil {
 			t.Fatalf("could not insert user %v: %v", v, err)
 		}
 	}
 	for _, v := range cs {
-		_, err := db.Exec("INSERT INTO cards (card_id, user_id) VALUES (?, ?)", v.ID, v.User)
+		_, err := db.Exec("INSERT INTO cards (card_id, user_id) VALUES ($1, $2)", v.ID, v.User)
 		if err != nil {
 			t.Fatalf("could not insert card %v: %v", v, err)
 		}
 	}
 	for _, v := range ts {
-		_, err := db.Exec("INSERT INTO transactions (transaction_id, user_id, card_id, time, amount, kind) VALUES (?, ?, ?, ?, ?, ?)", v.ID, v.User, v.Card, v.Time, v.Amount, v.Kind)
+		_, err := db.Exec("INSERT INTO transactions (transaction_id, user_id, card_id, time, amount, kind) VALUES ($1, $2, $3, $4, $5, $6)", v.ID, v.User, v.Card, v.Time, v.Amount, v.Kind)
 		if err != nil {
 			t.Fatalf("could not insert transaction %v: %v", v, err)
 		}


### PR DESCRIPTION
Postgres only understands the $1 placeholder syntax for prepared
statements, whereas sqlite understands both $1 and ? syntax (and MySQL
only understands ?). As we strive to support poth sqlite and postgres
for now, change the used syntax.