### PR TITLE
Enable build without libnfc

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,12 @@ func init() {
 	gob.Register(User{})
 }
 
+// NFCEvent contains an event at the NFC reader. Either UID or Err is nil.
+type NFCEvent struct {
+	UID []byte
+	Err error
+}
+
 // Kasse collects all state of the application in a central type, to make
 // parallel testing possible.
 type Kasse struct {

--- a/reader.go
+++ b/reader.go
@@ -1,3 +1,5 @@
+// +build !nonfc
+
 package main
 
 import (
@@ -8,12 +10,6 @@ import (
 
 	"github.com/fuzxxl/nfc/2.0/nfc"
 )
-
-// NFCEvent contains an event at the NFC reader. Either UID or Err is nil.
-type NFCEvent struct {
-	UID []byte
-	Err error
-}
 
 // DefaultModulation gives defaults for the modulation type and Baudrate.
 // Currently, only nfc.ISO14443a is supported for the type. If the default

--- a/reader_nonfc.go
+++ b/reader_nonfc.go
@@ -1,0 +1,11 @@
+// +build nonfc
+
+package main
+
+// ConnectAndPollNFCReader is a stub to enable a build without libnfc. It
+// blocks indefinitely.
+func ConnectAndPollNFCReader(conn string, ch chan NFCEvent) error {
+	block := make(chan bool)
+	<-block
+	return nil
+}


### PR DESCRIPTION
Building with go build -tags nonfc will now build a version without
libnfc, for testing (and running on travis docker infrastructure). It
won't be able to use nfc, but the HTTP mock reader still works.